### PR TITLE
Release 1.2

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -7,25 +7,37 @@ on:
   push:
     branches: ['release*']
 
-jobs:
-  build-and-push-to-dockerhub:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PATH: ghcr.io/${{ github.repository }}
 
-      - name: Log in to Docker Hub
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+          
+      - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: sagebionetworks/shiny-base${{github.GITHUB_REF_NAME}}
-
+          images: ${{ env.IMAGE_PATH }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{raw}}
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:focal
 
 RUN apt-get -y update && apt-get -y upgrade
 # The following is necessary to avoid an interactive prompt when installing r-base

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -y r-base r-base-dev
 RUN apt-get install -y libssl-dev libcurl4-openssl-dev libxml2-dev jq pip sudo python3-venv
 
 # cmake is needed to install some packages
-RUN apt-get install -y cmake
+RUN apt-get install -y cmake libxml2 libglpk-dev libicu-dev libicu66
 
 RUN Rscript -e "install.packages('shiny', repos='http://cran.rstudio.com/')"
 RUN apt-get install -y gdebi-core wget


### PR DESCRIPTION
A few things in this PR I am curious about your thoughts @brucehoff 

1. Fix the ubuntu image to focal to match the current deployment to shinyapps.io.
2. Push the container to the repo's ghcr.io package repository instead of docker. Similar to the DCA deploy.
3. Add system libraries for DCA R package dependencies.

Note for 3 above. I tried installing these dependencies in the DCA Dockerfile, but it prompts me for the shiny user password. You can't just `sudo apt-get install` . Is there a way to bypass when creating the base image. Or is it best practice to add system libraries to the base image as needed. I am trying to anticipate the needs for a variety of shiny apps using this base image.