### PR TITLE
Update shiny server to 1.5.21.1007

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y cmake
 
 RUN Rscript -e "install.packages('shiny', repos='http://cran.rstudio.com/')"
 RUN apt-get install -y gdebi-core wget
-RUN wget https://download3.rstudio.org/ubuntu-18.04/x86_64/shiny-server-1.5.19.995-amd64.deb
+RUN wget https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-18.04/x86_64/shiny-server-1.5.21.1007-amd64.deb
 RUN gdebi --n shiny-server-1.5.19.995-amd64.deb
 
 # remove the default landing page and link to sample app's


### PR DESCRIPTION
This release contains an updated node that resolves vulnerabilities found in our image scan. The URL points to their daily builds, which Posit support directed me to use. I am unsure when this will be incorporated into an "official" release.